### PR TITLE
[TS] add Icon as default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,9 +12,11 @@ declare module "react-icons-kit" {
     }
     export class Icon extends React.Component<IconProp> {}
     const withBaseIcon: (props: Pick<IconProp, Exclude<keyof IconProp, 'icon'>>) => React.SFC<IconProp>
+    export default Icon
 }
 
 declare module "react-icons-kit/icomoon"
+
 declare module "react-icons-kit/md"
 
 declare module "react-icons-kit/fa"


### PR DESCRIPTION
This PR adds `Icon` as the default export in the TS module declaration.

The original JS export can be seen [here](https://github.com/wmira/react-icons-kit/blob/master/src/index.js#L8)
```js
import { Icon, withBaseIcon } from './Icon';
import { horizontalCenter } from './horizontalCenter';

export { withBaseIcon };
export { Icon };
export { horizontalCenter };
export default Icon; // <-- here
```