### PR TITLE
Adding <span/> and <i/> to tag options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ site/bundle.js
 .react-playground
 site/build
 site/node_modules
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,11 @@
 
 declare module "react-icons-kit" {
     import * as React from 'react'
-    
+
     export interface IconProp {
         icon: any
         size?: number | string
+        tag?: string
         style?: React.CSSProperties
         className?: string
         onClick?: React.MouseEventHandler<HTMLDivElement>
@@ -40,7 +41,7 @@ declare module "react-icons-kit/typicons"
 declare module "react-icons-kit/noto_emoji_regular"
 
 declare module "react-icons-kit/feather"
-    
+
 
 declare module "react-icons-kit/icomoon/*"
 
@@ -67,4 +68,3 @@ declare module "react-icons-kit/typicons/*"
 declare module "react-icons-kit/noto_emoji_regular/*"
 
 declare module "react-icons-kit/feather/*"
-    

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -5,12 +5,14 @@ import PropTypes from 'prop-types';
 import SvgIcon from './SvgIcon';
 
 export const Icon = (props) => {
-    const { style, className, icon, size, ...others} = props; //eslint-disable-line
+    const { style, className, icon, size, tag, ...others} = props; //eslint-disable-line
+
+    const Tag = tag;
 
     return (
-        <div {...others} style={{display: 'inline-block',...style}} className={className}>
+        <Tag {...others} style={{display: 'inline-block',...style}} className={className}>
             <SvgIcon size={props.size} icon={props.icon} title={props.title} />
-        </div>
+        </Tag>
     );
 };
 
@@ -23,13 +25,15 @@ export const withBaseIcon = (defaultProps) => props => {
 
 Icon.defaultProps = {
     size: 16,
-    fill: 'currentColor'
+    fill: 'currentColor',
+    tag: 'i'
 };
 
 Icon.propTypes = {
     icon: PropTypes.object.isRequired,
     size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     style: PropTypes.object,
+    tag: PropTypes.oneOf(['i','span','div']),
     className: PropTypes.string
 };
 


### PR DESCRIPTION
@wmira,

Your react-icons-kit is very helpful!  Thank you for making if available.  I only wish we could use a different tag (other than `<div/>`) for the element.  So, I forked your master branch and added `<span/>` and `<i/>` as alternatives, letting the user decide which works best.  I also made `<i/>` the default.