### PR TITLE
Allow IconProp type definition to allow all HTML attributes.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 declare module "react-icons-kit" {
     import * as React from 'react'
 
-    export interface IconProp {
+    export interface IconProp extends React.HTMLAttributes<HTMLElement> {
         icon: any
         size?: number | string
         tag?: string


### PR DESCRIPTION
I was getting TypeScript errors when I tried to set regular HTML attributes like `tabIndex` and `onKeyDown` props to the Icon component. Since those additional props are working fine functionally, I think it's better to add this to the type declaration.