### PR TITLE
Don't discard fill=none

### DIFF
--- a/src/SvgIcon.js
+++ b/src/SvgIcon.js
@@ -19,6 +19,8 @@ const walkChildren = (children) => {
         let merge = {};
         if ( attribsMap.fill === 'none' && attribsMap.stroke ) {
             merge = { fill: 'none', stroke: 'currentColor' };
+        } else if ( attribsMap.fill === 'none' ) {
+            merge = { fill: 'none' };
         }
         return createElement(name, { key: idx, ...attribs, ...merge }, gchildren === null ? gchildren : walkChildren(gchildren));
     });
@@ -29,7 +31,7 @@ export const SvgIcon = (props) => {
 
     const { size } = props;
     const { children, viewBox, attribs: svgAttribs = {} } = props.icon;
-    
+
     const camelCasedAttribs = Object.keys(svgAttribs).reduce( (partial, key) => {
         partial[camelcase(key)] = svgAttribs[key]
         return partial


### PR DESCRIPTION
Is there a reason that the `fill` attribute is discarded in `SvgIcon`?

Some icons are using `fill=none` without an accompanying stroke (I'm not sure why):

https://github.com/google/material-design-icons/blob/ab12f16d050ecb1886b606f08825d24b30acafea/src/av/video_label/materialicons/24px.svg#L1

The current logic in SvgIcon only allows `fill=none` if there is an accompanying stroke, meaning these icons are not rendered correctly:

![image](https://user-images.githubusercontent.com/605824/120235055-143ffa80-c20e-11eb-8651-7e5d4a039397.png)

This seems like it is now the standard for material design icons, so it should probably be supported. I made the minimal possible change here in an attempt to resolve the immediate issue, is there a more appropriate fix that presents itself? I'm unclear on why the code was written this way in the first place.